### PR TITLE
[feature/wagwag-3] 공통 응답 통일 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/wagwag/TestController.java
+++ b/src/main/java/com/wagwag/TestController.java
@@ -1,0 +1,18 @@
+package com.wagwag;
+
+import com.wagwag.global.response.SuccessResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/test1")
+    public SuccessResponse<String> test1(){
+        return SuccessResponse.success("test");
+    }
+    @GetMapping("/test2")
+    public SuccessResponse<String> test2(){
+        return SuccessResponse.successWithoutResult("");
+    }
+}

--- a/src/main/java/com/wagwag/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wagwag/global/entity/BaseTimeEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseTimeEntity {
+public abstract class BaseTimeEntity {
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createAt;

--- a/src/main/java/com/wagwag/global/exception/BusinessException.java
+++ b/src/main/java/com/wagwag/global/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package com.wagwag.global.exception;
+
+import com.wagwag.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BusinessException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/wagwag/global/exception/BusinessException.java
+++ b/src/main/java/com/wagwag/global/exception/BusinessException.java
@@ -6,6 +6,6 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class BusinessException extends RuntimeException{
+public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
 }

--- a/src/main/java/com/wagwag/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/wagwag/global/exception/errorcode/CommonErrorCode.java
@@ -1,0 +1,28 @@
+package com.wagwag.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode{
+    // 공용 처리
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "4000", "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "4040", "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "알수없는 에러 관리자에게 문의"),
+
+    // 인증/인가 처리 (41xx)
+    JWT_EMPTY(HttpStatus.NO_CONTENT,"4100","JWT 토큰을 넣어주세요."),
+    JWT_INVALID(HttpStatus.BAD_REQUEST,"4101","다시 로그인 해주세요.(토큰이 유효하지 않습니다.)"),
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED,"4102","토큰이 만료되었습니다."),
+    JWT_BAD(HttpStatus.BAD_REQUEST,"4103","JWT 토큰이 잘못되었습니다."),
+    JWT_REFRESHTOKEN_NOT_MATCH(HttpStatus.CONFLICT,"4104","RefreshToken이 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "4105", "리프레시 토큰을 찾을 수 없습니다."),
+    JWT_AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED,"4106","권한이 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wagwag/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/wagwag/global/exception/errorcode/CommonErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum CommonErrorCode implements ErrorCode{
+public enum CommonErrorCode implements ErrorCode {
     // 공용 처리
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "4000", "Invalid parameter included"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "4040", "Resource not exists"),

--- a/src/main/java/com/wagwag/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/wagwag/global/exception/errorcode/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.wagwag.global.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/wagwag/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/wagwag/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package com.wagwag.global.exception.handler;
+
+import com.wagwag.global.exception.BusinessException;
+import com.wagwag.global.exception.errorcode.CommonErrorCode;
+import com.wagwag.global.exception.errorcode.ErrorCode;
+import com.wagwag.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Object> handleQuizException(final BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(final IllegalArgumentException e) {
+        log.warn("handleIllegalArgument", e);
+        final ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Object> handleIllegalArgument(final BadRequestException e) {
+        log.warn("handleBadRequest", e);
+        final ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @Override
+    @Nullable
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException e,
+            final HttpHeaders headers,
+            final HttpStatusCode statusCode,
+            final WebRequest request) {
+        log.warn("handleIllegalArgument", e);
+        final ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(e, errorCode);
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleAllException(final Exception ex) {
+        log.warn("handleAllException", ex);
+        final ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(final ErrorCode errorCode) {
+        return ErrorResponse.of(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode, final String message) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode, message));
+    }
+
+    private ErrorResponse makeErrorResponse(final ErrorCode errorCode, final String message) {
+        return ErrorResponse.of(errorCode, message);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(final BindException e, final ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(final BindException e, final ErrorCode errorCode) {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .forEach(ve -> errorResponse.getErrors().add(ve));
+
+        return errorResponse;
+    }
+}

--- a/src/main/java/com/wagwag/global/response/ApiResponse.java
+++ b/src/main/java/com/wagwag/global/response/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.wagwag.global.response;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ApiResponse {
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public ApiResponse(Boolean isSuccess, String code, String message) {
+        this.isSuccess = isSuccess;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/wagwag/global/response/ErrorResponse.java
+++ b/src/main/java/com/wagwag/global/response/ErrorResponse.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-public class ErrorResponse extends ApiResponse{
+public class ErrorResponse extends ApiResponse {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final List<ValidationError> errors = new ArrayList<>();

--- a/src/main/java/com/wagwag/global/response/ErrorResponse.java
+++ b/src/main/java/com/wagwag/global/response/ErrorResponse.java
@@ -1,0 +1,60 @@
+package com.wagwag.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wagwag.global.exception.errorcode.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ErrorResponse extends ApiResponse{
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors = new ArrayList<>();
+
+    private ErrorResponse(ErrorCode errorCode){
+        super(false, errorCode.getCode(), errorCode.getMessage());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode){
+        return new ErrorResponse(errorCode);
+    }
+
+    private ErrorResponse(ErrorCode errorCode, String message){
+        super(false, errorCode.getCode(), message);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message){
+        return new ErrorResponse(errorCode, message);
+    }
+
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{\n" +
+                "    \"isSuccess\":" + super.getIsSuccess() + ",\n" +
+                "    \"code\":\"" + super.getCode() + "\",\n" +
+                "    \"message\":\"" + super.getMessage() + "\"\n" +
+                "}";
+    }
+}

--- a/src/main/java/com/wagwag/global/response/ErrorResponse.java
+++ b/src/main/java/com/wagwag/global/response/ErrorResponse.java
@@ -20,15 +20,15 @@ public class ErrorResponse extends ApiResponse {
         super(false, errorCode.getCode(), errorCode.getMessage());
     }
 
-    public static ErrorResponse of(ErrorCode errorCode){
+    public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(errorCode);
     }
 
-    private ErrorResponse(ErrorCode errorCode, String message){
+    private ErrorResponse(ErrorCode errorCode, String message) {
         super(false, errorCode.getCode(), message);
     }
 
-    public static ErrorResponse of(ErrorCode errorCode, String message){
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
         return new ErrorResponse(errorCode, message);
     }
 

--- a/src/main/java/com/wagwag/global/response/SuccessResponse.java
+++ b/src/main/java/com/wagwag/global/response/SuccessResponse.java
@@ -1,0 +1,24 @@
+package com.wagwag.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+
+@Getter
+public class SuccessResponse<T> extends ApiResponse{
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final T result;
+
+    private SuccessResponse(T data){
+        super(true, "200", "OK");
+        this.result = data;
+    }
+
+    public static <T> SuccessResponse<T> success(T data){
+        return new SuccessResponse<>(data);
+    }
+    public static <T> SuccessResponse<T> successWithoutResult(T data){
+        return new SuccessResponse<>(null);
+    }
+}

--- a/src/main/java/com/wagwag/global/response/SuccessResponse.java
+++ b/src/main/java/com/wagwag/global/response/SuccessResponse.java
@@ -5,20 +5,20 @@ import lombok.Getter;
 
 
 @Getter
-public class SuccessResponse<T> extends ApiResponse{
+public class SuccessResponse<T> extends ApiResponse {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private final T result;
 
-    private SuccessResponse(T data){
+    private SuccessResponse(T data) {
         super(true, "200", "OK");
         this.result = data;
     }
 
-    public static <T> SuccessResponse<T> success(T data){
+    public static <T> SuccessResponse<T> success(T data) {
         return new SuccessResponse<>(data);
     }
-    public static <T> SuccessResponse<T> successWithoutResult(T data){
+    public static <T> SuccessResponse<T> successWithoutResult(T data) {
         return new SuccessResponse<>(null);
     }
 }

--- a/src/main/java/com/wagwag/post/domain/Comment.java
+++ b/src/main/java/com/wagwag/post/domain/Comment.java
@@ -1,7 +1,7 @@
 package com.wagwag.post.domain;
 
 import com.wagwag.global.entity.BaseTimeEntity;
-import com.wagwag.post.domain.Enum.CommentStatus;
+import com.wagwag.post.domain.enums.CommentStatus;
 import com.wagwag.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/wagwag/post/domain/Post.java
+++ b/src/main/java/com/wagwag/post/domain/Post.java
@@ -1,7 +1,7 @@
 package com.wagwag.post.domain;
 
 import com.wagwag.global.entity.BaseTimeEntity;
-import com.wagwag.post.domain.Enum.PostStatus;
+import com.wagwag.post.domain.enums.*;
 import com.wagwag.relation.domain.PostCategory;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/wagwag/post/domain/enums/CommentStatus.java
+++ b/src/main/java/com/wagwag/post/domain/enums/CommentStatus.java
@@ -1,4 +1,4 @@
-package com.wagwag.post.domain.Enum;
+package com.wagwag.post.domain.enums;
 
 public enum CommentStatus {
     ACTIVE, NONACTIVE

--- a/src/main/java/com/wagwag/post/domain/enums/PostStatus.java
+++ b/src/main/java/com/wagwag/post/domain/enums/PostStatus.java
@@ -1,4 +1,4 @@
-package com.wagwag.post.domain.Enum;
+package com.wagwag.post.domain.enums;
 
 public enum PostStatus {
     ACTIVE, NONACTIVE

--- a/src/main/java/com/wagwag/user/domain/User.java
+++ b/src/main/java/com/wagwag/user/domain/User.java
@@ -4,7 +4,7 @@ import com.wagwag.global.entity.BaseTimeEntity;
 import com.wagwag.post.domain.Comment;
 import com.wagwag.relation.domain.PostLike;
 import com.wagwag.relation.domain.UserCategory;
-import com.wagwag.user.domain.Enum.UserStatus;
+import com.wagwag.user.domain.enums.*;
 import jakarta.persistence.*;
 import lombok.*;
 import java.util.ArrayList;

--- a/src/main/java/com/wagwag/user/domain/enums/UserRole.java
+++ b/src/main/java/com/wagwag/user/domain/enums/UserRole.java
@@ -1,4 +1,4 @@
-package com.wagwag.user.domain.Enum;
+package com.wagwag.user.domain.enums;
 
 public enum UserRole {
     ROLE_USER, ROLE_ADMIN

--- a/src/main/java/com/wagwag/user/domain/enums/UserStatus.java
+++ b/src/main/java/com/wagwag/user/domain/enums/UserStatus.java
@@ -1,4 +1,4 @@
-package com.wagwag.user.domain.Enum;
+package com.wagwag.user.domain.enums;
 
 public enum UserStatus {
     ACTIVE, NONACTIVE


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - No

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 전역 예외 처리와 통일된 응답 형식을 제공하기 위해 GlobalExceptionHandler를 구현했습니다.
    
    - BusinessException, IllegalArgumentException, BadRequestException 등을 처리할 수 있는 공통 예외 핸들러를 작성하여 
     코드 중복을 줄이고, 일관된 에러 응답을 제공합니다.
   
    - 에러와 성공 응답을 위한 ErrorResponse와 SuccessResponse 클래스를 구현하여, API 응답의 통일성을 유지하였습니다.
    
    - 각종 예외 처리 시 적절한 HTTP 상태 코드와 메시지를 반환할 수 있도록 ErrorCode 인터페이스와 공통 에러 코드를 정의했습니다.
    
    (명인 추가 작업)
    + enum가 java 예약어인 관계로 기존 enum패키지명을 enums로 변경했습니다. enum패키지명 경로를 import하는 엔티티 쪽 코드
      이에 맞춰 모두 수정해주었습니다. 
    + 객체화할 필요가 없는 BaseTimeEntity를 클래스에서 추상클래스로 변경했습니다. 

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 예외 처리 로직이 모든 가능한 예외 상황을 적절히 커버하고 있는지, 추가적인 예외 유형에 대한 처리가 필요한지 검토 부탁드립니다.
    
    - 현재 구현된 ErrorResponse와 SuccessResponse가 프로젝트의 모든 API 응답에 대해 충분히 유연하고 확장 가능하도록 설계되었는지 확인해 주세요.
    
    - 예외 처리 시 handleExceptionInternal 메서드를 통한 공통 처리 방식이 적절한지, 더 나은 설계나 리팩토링 가능성이 있는지 논의해보고 싶습니다.

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [삭제] : spring security 처리를 아직 하지 않았기에, 테스트 시에 예외가 발생하여 주석처리 하였음.
